### PR TITLE
Remove walkthrough video

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,11 @@ This project involves building an API for a social network application using Exp
 
 ## Table of Contents
 
-- [Walkthrough Video](#walkthrough-video)
 - [Installation](#installation)
 - [Usage](#usage)
 - [Credits](#credits)
 - [License](#license)
 - [Questions](#questions)
-
-## Walkthrough Video
-
-https://www.loom.com/share/17b7a7b872b34bb3ad81b59b3be44896?sid=18eba730-0789-4c61-b0c4-db66f3952d21
 
 ## Installation
 1. Open your terminal and navigate to the directory where you want to store the repository.


### PR DESCRIPTION
This commit removes the walkthrough video that I had initially included for grading purposes. Due to an update in one of the routes, the video is not entirely correct, so I decided to remove it.